### PR TITLE
add bottomRight arrow direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,15 @@ You can draw arrows to point at DOM elements
 // all options are optional
 cy.get('.new-todo').arrow({
   duration: 3000,
-  blocking: true
+  blocking: true,
+  pointAt: 'bottomLeft', // or 'bottomRight'
+  offsetX: 0, // move the tip by X pixels
+  offsetY: 0, // move the tip by Y pixels
 })
 ```
 
 ![Arrow example screenshot](images/arrow.png)
+
 
 See [cypress/integration/arrow-spec.js](cypress/integration/arrow-spec.js) for examples
 

--- a/cypress/integration/arrow-spec.js
+++ b/cypress/integration/arrow-spec.js
@@ -19,4 +19,34 @@ describe('Arrows', () => {
     })
     .type('Did you see an arrow?!')
   })
+
+  it('from different directions', function () {
+    cy.visit('/examples/react/')
+
+    cy.get('.new-todo')
+      .type('Write test{enter}')
+      .type('Render test as demo movie{enter}')
+
+    cy.contains('.filters li', 'All').arrow({
+      duration: 1000,
+      offsetX: -10,
+      offsetY: 20,
+      blocking: true,
+    })
+
+    cy.contains('.filters li', 'Active').arrow({
+      duration: 1000,
+      offsetX: -10,
+      offsetY: 20,
+      blocking: true,
+    })
+
+    cy.contains('.filters li', 'Completed').arrow({
+      duration: 2000,
+      pointAt: 'bottomRight',
+      blocking: true,
+      offsetX: 50,
+      offsetY: 20,
+    })
+  })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,20 +24,51 @@ function getArrowSvg(c_e1, c_e2, strokeWidth = 1) {
 const arrowCommand = ($el, options = {}) => {
   Cypress._.defaults(options, {
     duration: 2000,
-    blocking: false
+    blocking: false,
+    offsetX: 0,
+    offsetY: 0,
+    // by default point at the element's bottom left corner
+    pointAt: 'bottomLeft'
   })
   // console.log('options', options)
   cy.log('**arrow**')
   const r = $el[0].getBoundingClientRect()
   // console.log('bounding box', r)
+
+  const directions = {
+    bottomLeft: {
+      x: 'left',
+      y: 'bottom'
+    },
+    bottomRight: {
+      x: 'right',
+      y: 'bottom'
+    }
+  }
+  const pointAt = directions[options.pointAt] || directions.bottomLeft
   const to = {
-    x: r.left,
-    y: r.bottom
+    x: r[pointAt.x] + options.offsetX,
+    y: r[pointAt.y] + options.offsetY,
   }
+
+  const arrowFromDirections = {
+    bottomLeft: {
+      x: -120,
+      y: 120
+    },
+    bottomRight: {
+      x: 120,
+      y: 120
+    }
+  }
+  const pointFrom = arrowFromDirections[options.pointAt] || arrowFromDirections.bottomLeft
+
   const from = {
-    x: r.left - 120,
-    y: r.bottom + 120
+    x: to.x + pointFrom.x,
+    y: to.y + pointFrom.y
   }
+  // console.log('arrow from', from, 'to', to)
+
   const doc = $el[0].ownerDocument
   const body = doc.body
 


### PR DESCRIPTION
- close #14 

```js
// all options are optional
cy.get('.new-todo').arrow({
  duration: 3000,
  blocking: true,
  pointAt: 'bottomLeft', // or 'bottomRight'
  offsetX: 0, // move the tip by X pixels
  offsetY: 0, // move the tip by Y pixels
})
```