### PR TITLE
fix: msToTimestamp  conversion

### DIFF
--- a/bin/record.js
+++ b/bin/record.js
@@ -22,7 +22,7 @@ const msToTimestamp = (ms) => {
   const hours = Math.floor(ms / (3600 * 1000))
   ms = ms % (3600 * 1000)
   const minutes = Math.floor(ms / (60 * 1000))
-  ms = ms % (3600 * 1000)
+  ms = ms % (60 * 1000)
   const seconds = Math.floor(ms / 1000)
   ms = ms % 1000
 


### PR DESCRIPTION
Before:
msToTimestamp(65544)
"0:1:65.444"

Now:
msToTimestamp(65544)
"0:1:5.544"